### PR TITLE
New `--campaign-path-fd` option for ben-sh

### DIFF
--- a/hpcbench/cli/bensh.py
+++ b/hpcbench/cli/bensh.py
@@ -2,6 +2,7 @@
 
 Usage:
   ben-sh [-v | -vv] [-r TAG] [-n HOST] [-o OUTDIR] [-l LOGFILE]
+         [--campaign-path-fd FD]
          [-g] CAMPAIGN_FILE
   ben-sh (-h | --help)
   ben-sh --version
@@ -16,11 +17,13 @@ Options:
                           a SLURM job.
   -h --help               Show this screen
   -g                      Generate a default YAML campaign file
+  --campaign-path-fd=FD   Write campaign path to file descriptor
   --version               Show version
   -v -vv                  Increase program verbosity
 """
 from __future__ import print_function
 
+import os
 import os.path as osp
 
 from hpcbench.campaign import Generator
@@ -47,4 +50,6 @@ def main(argv=None):
         driver()
         if argv is not None:
             return driver
-        print(osp.abspath(driver.campaign_path))
+        campaign_fd = int(arguments.get('--campaign-path-fd') or 1)
+        message = (osp.abspath(driver.campaign_path) + '\n').encode()
+        os.write(campaign_fd, message)

--- a/tests/test_campaign_fd.py
+++ b/tests/test_campaign_fd.py
@@ -1,0 +1,64 @@
+"""
+Test --campaign-path-fd option of ben-sh executable.
+"""
+import os
+import os.path as osp
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+class TestCampaignPathFd(unittest.TestCase):
+    CAMPAIGN_CONTENT = textwrap.dedent(
+        '''\
+        network:
+          nodes:
+            - localhost
+    '''
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        fd, cls.CAMPAIGN = tempfile.mkstemp(suffix='.yaml')
+        os.write(fd, cls.CAMPAIGN_CONTENT.encode())
+        os.close(fd)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.CAMPAIGN)
+
+    def bensh(self, fd=None):
+        bensh = osp.join(osp.dirname(sys.executable), 'ben-sh')
+        command = [bensh]
+        if fd:
+            command += ['--campaign-path-fd', str(fd)]
+        command.append(self.CAMPAIGN)
+        return subprocess.check_output(command, close_fds=False)
+
+    def test_default(self):
+        path = self.bensh().splitlines()[-1]
+        shutil.rmtree(path)
+
+    def test_fd_3(self):
+        fd, path = tempfile.mkstemp()
+        # dirty workaround before mkstemp() returns non-inheritable fd
+        os.close(fd)
+        fd = os.open(path, os.O_RDWR | os.O_CREAT)
+        # ---
+        if hasattr(os, 'set_inheritable'):
+            os.set_inheritable(fd, True)
+        self.bensh(fd)
+        os.close(fd)
+        # 'path' file must have absolute path to campaign
+        with open(path) as istr:
+            content = istr.read()
+        os.remove(path)
+        lines = content.splitlines(True)
+        self.assertEqual(1, len(lines))
+        campaign_path = lines[0][:-1]
+        self.assertTrue(osp.isdir(campaign_path))
+        self.assertTrue(osp.isabs(campaign_path))
+        shutil.rmtree(campaign_path)


### PR DESCRIPTION
Allows to write campaign path in a dedicated file descriptor.
Fixes #236