### PR TITLE
ben-wait writes summary to console and exit 1 if a benchmark failed

### DIFF
--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -571,6 +571,8 @@ class ReportNode(collections.Mapping):
     """Navigate across hpcbench.yaml files of a campaign
     """
 
+    CONTEXT_ATTRS = ['node', 'tag', 'benchmark', 'category', 'attempt']
+
     def __init__(self, path):
         """
         :param path: path to an existing campaign directory
@@ -592,7 +594,7 @@ class ReportNode(collections.Mapping):
         prefix = os.path.commonprefix([path, self._path])
         relative_path = path[len(prefix) :]
         relative_path = relative_path.strip(os.sep)
-        attrs = ['node', 'tag', 'benchmark', 'category', 'attempt']
+        attrs = self.CONTEXT_ATTRS
         for i, elt in enumerate(relative_path.split(os.sep)):
             yield attrs[i], elt
         yield 'path', path

--- a/hpcbench/cli/benwait.py
+++ b/hpcbench/cli/benwait.py
@@ -1,21 +1,34 @@
 """ben-wait - Wait for asynchronous processes
 
 Usage:
-  ben-wait [-v | -vv] [--interval=<seconds>] [-l LOGFILE] CAMPAIGN-DIR
+  ben-wait [-v | -vv] [--interval=<seconds>] [-l LOGFILE]
+           [--silent] [--format=<format>]
+           CAMPAIGN-DIR
   ben-wait (-h | --help)
   ben-wait --version
 
 Options:
   -l --log=LOGFILE                    Specify an option logfile to write to.
   -n <seconds>, --interval <seconds>  Specify wait interval [default: 10].
+  -s --silent                         Do you write campaign status to console
+  -f --format=FORMAT                  Campaign status output format.
+                                      possible values: json, yaml, log[default]
   -h --help                           Show this screen.
   --version                           Show version.
   -v -vv                              Increase program verbosity.
-"""
 
+Exit status:
+  exits 1 if at least one of the benchmark executions fails, 0 otherwise.
+"""
+from __future__ import print_function
+import json
 import logging
 import subprocess
+import sys
 import time
+
+from cached_property import cached_property
+import yaml
 
 from hpcbench.campaign import ReportNode
 from hpcbench.toolbox.functools_ext import listify
@@ -23,12 +36,78 @@ from hpcbench.toolbox.process import find_executable
 from . import cli_common
 
 
-def is_slurm_job_terminated(jobid):
+def is_slurm_job_terminated(sacct, jobid):
     output = subprocess.check_output(
-        [find_executable('sacct'), '-n', '-X', '-o', "end", '-j', str(jobid)]
+        [sacct, '-n', '-X', '-o', "end", '-j', str(jobid)]
     )
     end = output.strip().decode()
     return end not in {'Unknown', ''}
+
+
+class ReportStatus:
+    """Build a dictionary reporting benchmarks execution status"""
+    def __init__(self, report, job_ids):
+        self.__report = report
+        self.__job_ids = job_ids
+
+    @property
+    def slurm_sbatches(self):
+        return bool(self.__job_ids)
+
+    @property
+    def report(self):
+        return self.__report
+
+    @property
+    def job_ids(self):
+        return self.__job_ids
+
+    @cached_property
+    def status(self):
+        status = dict(benchmarks=self._benchmarks_status())
+        if self.slurm_sbatches:
+            status.update(slurm_jobs=self.job_ids)
+        return status
+
+    @cached_property
+    def successfull(self):
+        return all(
+            benchmark['succeeded']
+            for benchmark in self.status['benchmarks']
+        )
+
+    def log(self, fmt):
+        if fmt == 'yaml':
+            yaml.dump(self.status, sys.stdout, default_flow_style=False)
+        elif fmt == 'json':
+            json.dump(self.status, sys.stdout, indent=2)
+            print()
+        elif fmt == 'log':
+            attrs = self.report.CONTEXT_ATTRS + ['succeeded']
+            for benchmark in self.status['benchmarks']:
+                fields = [
+                    field + '=' + str(benchmark[field])
+                    for field in attrs
+                ]
+                print(*fields)
+        else:
+            raise Exception('Unknown format: ' + fmt)
+
+    @listify
+    def _benchmarks_status(self):
+        roots = []
+        if self.slurm_sbatches:
+            for sbatch in self.report.children.values():
+                for tag in sbatch.children.values():
+                    assert len(tag.children) == 1
+                    roots.append(tag.children.values()[0])
+        else:
+            roots.append(self.report)
+        for root in roots:
+            for path, succeeded in root.collect('command_succeeded', with_path=True):
+                ctx = root.path_context(path)
+                ctx.update(succeeded=succeeded)
+                yield ctx
 
 
 @listify
@@ -41,12 +120,19 @@ def wait_for_completion(report, interval=10):
     :type interval: int or float
     :return: list of asynchronous job identifiers
     """
+    try:
+        sacct = find_executable('sacct')
+    except NameError:
+        sacct = None
+    if not sacct:
+        logging.warn('Could not find executable sacct')
     for jobid in report.collect('jobid'):
-        if not is_slurm_job_terminated(jobid):
-            logging.info('waiting for SLURM job %s', jobid)
-            time.sleep(interval)
-            while not is_slurm_job_terminated(jobid):
+        if sacct:
+            if not is_slurm_job_terminated(sacct, jobid):
+                logging.info('waiting for SLURM job %s', jobid)
                 time.sleep(interval)
+                while not is_slurm_job_terminated(sacct, jobid):
+                    time.sleep(interval)
         yield jobid
 
 
@@ -54,4 +140,11 @@ def main(argv=None):
     """ben-wait entry point"""
     arguments = cli_common(__doc__, argv=argv)
     report = ReportNode(arguments['CAMPAIGN-DIR'])
-    wait_for_completion(report, float(arguments['--interval']))
+    job_ids = wait_for_completion(report, float(arguments['--interval']))
+    status = ReportStatus(report, job_ids)
+    if not arguments['--silent']:
+        fmt = arguments['--format'] or 'log'
+        status.log(fmt)
+    if argv is None:
+        sys.exit(0 if status.successfull else 1)
+    return status.status

--- a/hpcbench/toolbox/collections_ext.py
+++ b/hpcbench/toolbox/collections_ext.py
@@ -48,6 +48,9 @@ class nameddict(dict):  # pragma pylint: disable=invalid-name
         return result
 
 
+yaml.add_representer(nameddict, SafeRepresenter.represent_dict)
+
+
 class Configuration(nameddict):
     """nameddict reflecting a YAML file
     """

--- a/tests/test_benwait.py
+++ b/tests/test_benwait.py
@@ -91,5 +91,6 @@ class TestBenWait(unittest.TestCase):
     def test_benwait_executable(self):
         """Test ben-wait entry-point"""
         with sacct().r().cd().r().cd().mock() as mock:
-            benwait(["-n", "0.5", self.REPORT.path])
+            status = benwait(["-n", "0.5", self.REPORT.path])
+        six.assertCountEqual(self, status['slurm_jobs'], [1, 2])
         self.assertEqual(mock.call_count, 4)


### PR DESCRIPTION
One may want to ensure that a campaign successfully ran before sending metrics to Elasticsearch. So far there is not way to have this information easily.
Instead of creating another cli utility, this pull-request updates `ben-wait` utility so that:
* its exit status tells whether there have been issues or not
* it writes to console a short summary of how benchmarks performed, available in different formats. `--silent` option discards this output.

For instance:
```
$ ben-wait path/to/campaign
node=node01 tag=tag01 benchmark=minigemm category=minigemm attempt=7263eab0-d24f-4ac7-adde-5f752883d739 succeeded=True

$ ben-wait  --format json path/to/campaign
{
  "slurm_jobs": [
    19473
  ], 
  "benchmarks": [
    {
      "node": "node01", 
      "category": "minigemm", 
      "attempt": "7263eab0-d24f-4ac7-adde-5f752883d739", 
      "succeeded": true, 
      "benchmark": "minigemm", 
      "tag": "tag01", 
      "path": "path/to/benchmark/results"
    }
  ]
}

$ ben-wait  --format yaml path/to/campaign
benchmarks:
- attempt: 7263eab0-d24f-4ac7-adde-5f752883d739
  benchmark: minigemm
  category: minigemm
  node: node01
  path: path/to/benchmark/results
  succeeded: true
  tag: tag01
slurm_jobs:
- 19473
```