### PR TITLE
Manage Spack specifications

### DIFF
--- a/docs/campaign.rst
+++ b/docs/campaign.rst
@@ -110,7 +110,7 @@ All methods are being used:
 * **tags** expects a list of tag names
 
 * **constraint** expects a string. This tag does not references node
-  names explicitely but instead delegates it to SLURM. The value of the
+  names explicitly but instead delegates it to SLURM. The value of the
   constraint tag is given to the sbatch options through the
   *--constraint* option.
 
@@ -275,7 +275,7 @@ options, which are passed to the `srun` command. Note that only the long form
 option names should be used (i.e. `--nodes` instead of `-N`). These options overwrite
 the global options provided in the :ref:`process <campaign-process>` section. To disable
 a global srun option simply declare the option without providing a value. if an option without
-value (e.g. `--exclusvie`) is to be used in `srun`, the key should be assigned to `true`.
+value (e.g. `--exclusive`) is to be used in `srun`, the key should be assigned to `true`.
 
 .. code-block:: yaml
   :emphasize-lines: 4,7,8
@@ -289,6 +289,27 @@ value (e.g. `--exclusvie`) is to be used in `srun`, the key should be assigned t
           hint:
           exclusive: true
         type: osu
+
+spack (optional)
+~~~~~~~~~~~~~~~~
+Dictionary to specify spack related configuration. Supported attributes are:
+
+* **specs**: list of spack specs to install before executing benchmarks.
+  `bin` directory of install directories are be prepended to `PATH`.
+
+For instance:
+
+.. code-block:: yaml
+  :emphasize-lines: 5-7
+
+  benchmarks:
+      '*':
+          test01:
+              type: stream
+              spack:
+                  specs:
+                  - stream@intel+openmp
+
 
 attempts (optional)
 ~~~~~~~~~~~~~~~~~~~
@@ -310,7 +331,7 @@ the ``fixed`` option.
                   fixed: 2
 
 All executions are present in the report but only metrics of the last run are reported. The
-``sorted`` key allows to change this behavior to reorder the runs according to criterias.
+``sorted`` key allows to change this behavior to reorder the runs according to criteria.
 
 .. code-block:: yaml
   :emphasize-lines: 6-8
@@ -462,7 +483,7 @@ the binaries.
     type: slurm
     commands:
       sbatch: /opt/slurm/bin/sbatch
-      srun: /opt/slrum/bin/sbatch
+      srun: /opt/slurm/bin/sbatch
 
 srun and sbatch (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hpcbench/toolbox/spack.py
+++ b/hpcbench/toolbox/spack.py
@@ -1,0 +1,24 @@
+from subprocess import check_call, check_output
+
+from . process import find_executable
+
+
+class SpackCmd:
+    @property
+    def spack(self):
+        return find_executable('spack', required=False)
+
+    def install(self, *args):
+        self.cmd('install', '--show-log-on-error', '--verbose', *args)
+
+    def install_dir(self, *args):
+        output = self.cmd('location', '--install-dir', *args, output=True)
+        return output.strip().decode('utf-8')
+
+    def cmd(self, *args, **kwargs):
+        command = [self.spack] + list(args)
+        if kwargs.get('output', False):
+            func = check_output
+        else:
+            func = check_call
+        return func(command)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,12 +26,16 @@ class DriverTestCase(object):
 
     @classmethod
     def setUpClass(cls):
-        cls.TEST_DIR = tempfile.mkdtemp(prefix='hpcbench-ut')
+        cls.TEST_DIR = cls.mkdtemp()
         with pushd(cls.TEST_DIR):
             cls.driver = bensh.main(cls.get_campaign_file())
         cls.CAMPAIGN_PATH = osp.join(cls.TEST_DIR, cls.driver.campaign_path)
         if cls.check_campaign_consistency:
             cls._check_campaign_consistency()
+
+    @classmethod
+    def mkdtemp(cls):
+        return tempfile.mkdtemp(prefix='hpcbench-ut')
 
     @classmethod
     def _check_campaign_consistency(cls):

--- a/tests/test_benwait.py
+++ b/tests/test_benwait.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import os.path as osp
 import shutil
-import tempfile
 import unittest
 
 import mock
@@ -11,6 +10,7 @@ import yaml
 
 from hpcbench.campaign import ReportNode, YAML_REPORT_FILE
 from hpcbench.cli.benwait import main as benwait, wait_for_completion
+from . import DriverTestCase
 
 
 class sacct:
@@ -64,7 +64,7 @@ class TestBenWait(unittest.TestCase):
 
     @classmethod
     def _create_fake_campaign(cls):
-        campaign = tempfile.mkdtemp()
+        campaign = DriverTestCase.mkdtemp()
         with open(osp.join(campaign, YAML_REPORT_FILE), 'w') as ostr:
             yaml.dump(dict(children=['sbatch1', 'sbatch2']), ostr)
         for jobid in range(1, 3):

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -2,13 +2,12 @@ import csv
 import inspect
 import os.path as osp
 import shutil
-import tempfile
 import unittest
 
 from hpcbench.cli import bencsv, bensh
 from hpcbench.export.csvexport import CSVExporter
 from hpcbench.toolbox.contextlib_ext import pushd
-from . import FakeBenchmark
+from . import DriverTestCase, FakeBenchmark
 
 
 class TestCSV(unittest.TestCase):
@@ -17,7 +16,7 @@ class TestCSV(unittest.TestCase):
     PERFORMANCE_METRIC = 'metrics.0.measurement.performance'
 
     def setUp(self):
-        self.temp_dir = tempfile.mkdtemp(prefix='hpcbench-ut')
+        self.temp_dir = DriverTestCase.mkdtemp()
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)

--- a/tests/test_cwd.py
+++ b/tests/test_cwd.py
@@ -1,4 +1,5 @@
 import socket
+import os
 import unittest
 
 from hpcbench.campaign import ReportNode
@@ -8,7 +9,8 @@ from . import DriverTestCase
 class CwdTest(DriverTestCase, unittest.TestCase):
     def test(self):
         host = socket.gethostname()
-        path = '/tmp/hpcbench-ut/test_cwd/' + host + '/*'
+        tempdir = os.path.realpath('/tmp')
+        path = tempdir + '/hpcbench-ut/test_cwd/' + host + '/*'
         report = ReportNode(CwdTest.CAMPAIGN_PATH)
         count = 0
         for metrics in report.collect('metrics'):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,17 +1,17 @@
 import inspect
 import os.path as osp
 import shutil
-import tempfile
 import unittest
 
 from hpcbench.campaign import merge_campaigns
 from hpcbench.cli import benmerge, bensh
 from hpcbench.toolbox.contextlib_ext import pushd
+from . import DriverTestCase
 
 
 class TestMerge(unittest.TestCase):
     def setUp(self):
-        self.temp_dir = tempfile.mkdtemp(prefix='hpcbench-ut')
+        self.temp_dir = DriverTestCase.mkdtemp()
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -4,7 +4,6 @@ import os.path as osp
 import shutil
 import stat
 import subprocess
-import tempfile
 import textwrap
 import unittest
 
@@ -24,7 +23,7 @@ class TestSlurm(DriverTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.SLURM_ALLOC_NODE = 'n3'
-        cls.SLURM_UT_DIR = tempfile.mkdtemp(prefix='hpcbench-ut')
+        cls.SLURM_UT_DIR = cls.mkdtemp()
         sbatch_ut = osp.join(cls.SLURM_UT_DIR, 'sbatch-ut')
         with open(sbatch_ut, 'w') as ostr:
             ostr.write(

--- a/tests/test_spack.py
+++ b/tests/test_spack.py
@@ -1,0 +1,53 @@
+import mock
+import os
+import os.path as osp
+import shutil
+import sys
+import unittest
+
+from hpcbench.campaign import ReportNode
+from . import DriverTestCase
+
+
+FOO_INSTALL_DIR = DriverTestCase.mkdtemp()
+
+
+def co_mock(command):
+    if command[1:4] == ['location', '--install-dir', 'foo@dev']:
+        return (FOO_INSTALL_DIR + '\n').encode()
+    raise NotImplementedError
+
+
+def cc_mock(command):
+    if command[1] == 'install' and command[-1] == 'foo@dev':
+        return
+    with open('/tmp/foo.txt', 'w') as ostr:
+        ostr.write(repr(command))
+    raise NotImplementedError
+
+
+CO_MOCK = mock.Mock(side_effect=co_mock)
+CC_MOCK = mock.Mock(side_effect=cc_mock)
+
+
+class TestSpack(DriverTestCase, unittest.TestCase):
+    @classmethod
+    @mock.patch('hpcbench.toolbox.spack.check_output', new=CO_MOCK)
+    @mock.patch('hpcbench.toolbox.spack.check_call', new=CC_MOCK)
+    def setUpClass(cls):
+        # prepare spack install directory of 'foo' package
+        bin_dir = osp.join(FOO_INSTALL_DIR, 'bin')
+        foo_python = osp.join(bin_dir, 'foo-python')
+        os.mkdir(bin_dir)
+        os.symlink(sys.executable, foo_python)
+        super(cls, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(FOO_INSTALL_DIR)
+        super(cls, cls).tearDownClass()
+
+    def test(self):
+        report = ReportNode(self.CAMPAIGN_PATH)
+        data = list(report.collect('command_succeeded'))
+        self.assertEqual(data, [True] * 3)

--- a/tests/test_spack.yaml
+++ b/tests/test_spack.yaml
@@ -1,0 +1,7 @@
+benchmarks:
+  '*':
+    bench-name:
+      type: fake
+      spack: {specs: [foo@dev]}
+      attributes:
+        executable: foo-python

--- a/tests/test_srun.py
+++ b/tests/test_srun.py
@@ -3,7 +3,6 @@ import os
 import os.path as osp
 import shutil
 import stat
-import tempfile
 import textwrap
 import unittest
 
@@ -15,7 +14,7 @@ class TestSrun(DriverTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.SLURM_ALLOC_NODE = 'n3'
-        cls.SLURM_UT_DIR = tempfile.mkdtemp(prefix='hpcbench-ut')
+        cls.SLURM_UT_DIR = cls.mkdtemp()
         srun_ut = osp.join(cls.SLURM_UT_DIR, 'srun-ut')
         with open(srun_ut, 'w') as ostr:
             ostr.write(


### PR DESCRIPTION
This pull-request adds capability to specify Spack specs in YAML that are installed before executing benchmarks.