### PR TITLE
sbatch: look for ben-sh script in stack

### DIFF
--- a/hpcbench/benchmark/babelstream.py
+++ b/hpcbench/benchmark/babelstream.py
@@ -54,6 +54,7 @@ class BabelStreamExtractor(MetricsExtractor):
 
 class BabelStream(Benchmark):
     """STREAM, for lots of different devices"""
+
     DEFAULT_EXECUTABLE = 'cuda-stream'
     CATEGORY = 'stream'
 

--- a/hpcbench/benchmark/imb.py
+++ b/hpcbench/benchmark/imb.py
@@ -283,7 +283,7 @@ class IMB(Benchmark):
                 yield dict(
                     category=category,
                     command=[find_executable(self.executable, required=False), category]
-                    + arguments,
+                    + list(arguments),
                     srun_nodes=self.srun_nodes,
                 )
 

--- a/hpcbench/benchmark/nvidia.py
+++ b/hpcbench/benchmark/nvidia.py
@@ -181,6 +181,7 @@ class NvidiaP2pBandwidthLatencyTest(Benchmark):
 class NvidiaBandwidthTest(Benchmark):
     """measure the memcopy bandwidth of the GPU and memcpy bandwidth across PCI-e
     """
+
     DEFAULT_EXECUTABLE = 'bandwidthTest'
     DEFAULT_DEVICE = 0
     DEFAULT_MODE = 'shmoo'

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -219,6 +219,8 @@ def default_campaign(campaign=None, expandcampvars=True, exclude_nodes=None,
     else:
         campaign = nameddict(campaign)
     if expandcampvars:
+        if campaign.network.get('tags') is None:
+            campaign.network['tags'] = {}
         NetworkConfig(campaign).expand()
     return freeze(campaign) if frozen else campaign
 

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -172,8 +172,9 @@ def from_file(campaign_file, **kwargs):
     return default_campaign(campaign, **kwargs)
 
 
-def default_campaign(campaign=None, expandcampvars=True, exclude_nodes=None,
-                     frozen=True):
+def default_campaign(
+    campaign=None, expandcampvars=True, exclude_nodes=None, frozen=True
+):
     """Fill an existing campaign with default
     values for optional keys
 

--- a/hpcbench/cli/bensh.py
+++ b/hpcbench/cli/bensh.py
@@ -47,8 +47,11 @@ def main(argv=None):
         exclude_nodes = arguments.get('--exclude-nodes')
         srun_tag = arguments.get('--srun')
         driver = CampaignDriver(
-            campaign_file, node=node, output_dir=output_dir, srun=srun_tag,
-            exclude_nodes=exclude_nodes
+            campaign_file,
+            node=node,
+            output_dir=output_dir,
+            srun=srun_tag,
+            exclude_nodes=exclude_nodes,
         )
         driver()
         if argv is not None:

--- a/hpcbench/driver/campaign.py
+++ b/hpcbench/driver/campaign.py
@@ -99,8 +99,9 @@ class CampaignDriver(Enumerator):
             else:
                 # YAML file
                 self.existing_campaign = False
-            campaign = from_file(campaign, expandcampvars=expandcampvars,
-                                 exclude_nodes=exclude_nodes)
+            campaign = from_file(
+                campaign, expandcampvars=expandcampvars, exclude_nodes=exclude_nodes
+            )
             self.campaign_file = campaign_path
         else:
             self.existing_campaign = True

--- a/hpcbench/driver/slurm.py
+++ b/hpcbench/driver/slurm.py
@@ -1,8 +1,10 @@
 from collections import Mapping
 import datetime
+import inspect
 import logging
 import re
 import subprocess
+import os
 from os import path as osp
 import sys
 
@@ -83,10 +85,16 @@ class SbatchDriver(Enumerator):
 
     @cached_property
     def bensh_executable(self):
-        bensh = osp.realpath(osp.join(osp.dirname(sys.executable), 'ben-sh'))
-        if osp.exists(bensh):
-            return bensh
-        return 'ben-sh'
+        candidates = []
+        main_script = inspect.stack()[-1][1]
+        if main_script.endswith('ben-sh'):
+            candidates.append(osp.realpath(osp.join(os.getcwd(), main_script)))
+        candidates.append(osp.realpath(osp.join(osp.dirname(sys.executable), 'ben-sh')))
+        candidates.append('ben-sh')
+        for candidate in candidates:
+            if osp.exists(candidate):
+                break
+        return candidate
 
     @property
     def default_job_name(self):

--- a/hpcbench/driver/slurm.py
+++ b/hpcbench/driver/slurm.py
@@ -133,8 +133,9 @@ class SbatchDriver(Enumerator):
         return sbatch_options
 
     def _filter_nodes(self, nodes, count):
-        assert count <= len(nodes), \
-            "Expected # of nodes <= {} but got {}".format(count, len(nodes))
+        assert count <= len(nodes), "Expected # of nodes <= {} but got {}".format(
+            count, len(nodes)
+        )
         if count < len(nodes):
             self.logger.warning(
                 "Asking to run SBATCH job with " "%d of %d declared nodes in tag",

--- a/hpcbench/templates/hpcbench.yaml.jinja
+++ b/hpcbench/templates/hpcbench.yaml.jinja
@@ -30,17 +30,15 @@ network:
 benchmarks:
   # * is an implicit tag, including all nodes
   '*':
-    # arbitrary name
-    default:
 {%- for b in benchmarks %}
-
+    test-{{ b.name }}: # name is arbitrary
       {{ b.description }}
-      {{ b.name }}:
+      type: {{ b.name }}
 {%- if b.attributes %}
-        attributes:
+      attributes:
 {%- for attr, rec in b.attributes.items() %}
-          {{ rec['doc'] }}
-          {{ attr }}: {{ rec['value'] | safe }}
+        {{ rec['doc'] }}
+        {{ attr }}: {{ rec['value'] | safe }}
 
 {%- endfor %}
 {%- endif %}

--- a/hpcbench/toolbox/slurm/cluster.py
+++ b/hpcbench/toolbox/slurm/cluster.py
@@ -1,6 +1,7 @@
 import collections
 import datetime
 import csv
+import logging
 import re
 import subprocess
 
@@ -67,7 +68,11 @@ class SlurmCluster:
     @classmethod
     def discover_partitions(cls):
         command = [SINFO, '--Node', '--format', '%all']
-        output = subprocess.check_output(command, env=SINFO_ENV)
+        try:
+            output = subprocess.check_output(command, env=SINFO_ENV)
+        except OSError:
+            logging.exception('Could not extract cluster information')
+            return dict()
         reader = csv.DictReader(output.decode().splitlines(), delimiter='|')
         sanitizer_re = re.compile('[^0-9a-zA-Z]+')
 

--- a/hpcbench/toolbox/spack.py
+++ b/hpcbench/toolbox/spack.py
@@ -1,6 +1,6 @@
 from subprocess import check_call, check_output
 
-from . process import find_executable
+from .process import find_executable
 
 
 class SpackCmd:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -141,6 +141,7 @@ class BuildInfoBench(Benchmark):
 
 class FakeBenchmark(Benchmark):
     """Fake benchmark for HPCBench testing purpose"""
+
     name = 'fake'
 
     INPUTS = [10, 20, 100]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -46,6 +46,7 @@ POPEN_MOCK = mock.Mock(side_effect=popen_module_load)
 
 class EnvBenchmark(Benchmark):
     """only for testing purpose"""
+
     MODULE_TO_VAR_RE = re.compile('[^0-9a-zA-Z]+')
 
     name = "environment"

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -76,8 +76,9 @@ class TestSlurm(DriverTestCase, unittest.TestCase):
             self.assertFalse(sbatch_content[-1].find(tag) == -1)
             self.assertIn(self.CONSTRAINT, sbatch_content)
             if self.EXCLUDE_NODES:
-                self.assertIn('--exclude-nodes=' + self.EXCLUDE_NODES + ' ',
-                              sbatch_content[-1])
+                self.assertIn(
+                    '--exclude-nodes=' + self.EXCLUDE_NODES + ' ', sbatch_content[-1]
+                )
             data = slurm_report.collect_one('metrics')
             dummy = kwargsql.get(data, '0__measurement__dummy')
             self.assertEqual(dummy, 42.0)


### PR DESCRIPTION
This patch adds a new way to find absolute path to ` ben-sh` executable used in generated sbatches.