### PR TITLE
benchmark environment variable: enforce type of passed values

### DIFF
--- a/hpcbench/driver/base.py
+++ b/hpcbench/driver/base.py
@@ -84,7 +84,7 @@ class Enumerator(six.with_metaclass(ABCMeta, object)):
 
     @abstractproperty
     def children(self):
-        """Property to be overriden be subclass to provide child objects"""
+        """Property to be overriden by subclass to provide child objects"""
         raise NotImplementedError  # pragma: no cover
 
     @cached_property

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -215,9 +215,7 @@ class FakeBenchmark(Benchmark):
         ]
         if self.run_path:
             for cmd in cmds:
-                cmd.update(
-                    environment=dict(SHOW_CWD='1'), cwd=self.run_path
-                )
+                cmd.update(environment=dict(SHOW_CWD='1'), cwd=self.run_path)
         return cmds
 
     @property

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -145,18 +145,22 @@ class TestEnvironment(DriverTestCase, unittest.TestCase):
     def expected_env(self):
         return from_file(self.get_campaign_file())['expected_env']
 
+    @cached_property
+    def errors(self):
+        return set(from_file(self.get_campaign_file())['errors'])
+
     def test(self):
         report = ReportNode(self.CAMPAIGN_PATH)
         keys = ('modules', 'environment', 'metas')
-        expected_tests = 13
+        expected_tests = 14
         tests = 0
         for path, env in report.collect(*keys, with_path=True):
-            self.driver.logger.error('path: %s', path)
             context = report.path_context(path)
             self._check_campaign_report(context, env)
             self._check_shell_script(context)
             self._check_benchmark_hooks_environment(context)
             self._check_metas(env)
+            self.assertNotIn(context.benchmark, self.errors)
             tests += 1
         self.assertEqual(tests, expected_tests)
 

--- a/tests/test_environment.yaml
+++ b/tests/test_environment.yaml
@@ -89,13 +89,39 @@ benchmarks:
             attributes:
                 environment:
                     FOO: bar
-
+        integral_types:
+            type: environment
+            environment:
+                FOO: 42
+                BAR: 42.0
+        bool_is_forbiden:
+            type: environment
+            environment:
+                FOO: true
+        array_is_forbidden:
+            type: environment
+            environment:
+                FOO: [42]
+        dict_is_forbidden:
+            type: environment
+            environment:
+                FOO: {42: 42}
 
 metas:
     foo: bar
     bar: pika
 
+errors:
+    - bool_is_forbiden
+    - array_is_forbidden
+    - dict_is_forbidden
+
 expected_env:
+    integral_types:
+        modules: []
+        environment:
+            FOO: "42"
+            BAR: "42.0"
     as_is:
         modules: []
         environment: {}


### PR DESCRIPTION
Only int, float, and string are accepted.
fixes #256