### PR TITLE
Enable Elasticsearch HTTP basic auth

### DIFF
--- a/hpcbench/export/es.py
+++ b/hpcbench/export/es.py
@@ -9,7 +9,7 @@ from elasticsearch import Elasticsearch
 import six
 
 from hpcbench.campaign import from_file, get_metrics, ReportNode
-from hpcbench.toolbox.collections_ext import dict_merge
+from hpcbench.toolbox.collections_ext import dict_merge, defrost
 from hpcbench.toolbox.functools_ext import chunks
 
 
@@ -43,7 +43,8 @@ class ESExporter(object):
         """Get Elasticsearch client
         """
         es_conf = self.campaign.export.elasticsearch
-        return Elasticsearch(self.hosts, **es_conf.connection_params)
+        connection_params = defrost(es_conf.connection_params)
+        return Elasticsearch(self.hosts, **connection_params)
 
     @cached_property
     def index_client(self):

--- a/hpcbench/toolbox/collections_ext.py
+++ b/hpcbench/toolbox/collections_ext.py
@@ -207,6 +207,9 @@ class FrozenList(collections.Sequence):
     def __init__(self, *args, **kwargs):
         self._l = list(*args, **kwargs)
 
+    def __iter__(self):
+        return iter(self._l)
+
     def __getitem__(self, i):
         return self._l[i]
 
@@ -239,5 +242,16 @@ def freeze(obj):
         return FrozenDict({freeze(k): freeze(v) for k, v in six.iteritems(obj)})
     elif isinstance(obj, list):
         return FrozenList([freeze(e) for e in obj])
+    else:
+        return obj
+
+
+def defrost(obj):
+    """Transform tree of frozen dict and list to regular, mutable ones
+    """
+    if isinstance(obj, FrozenDict):
+        return {defrost(k): defrost(v) for k, v in six.iteritems(obj)}
+    elif isinstance(obj, FrozenList):
+        return [defrost(e) for e in obj]
     else:
         return obj

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'clustershell>=1.8',
         'cookiecutter==1.6.0',
         'docopt==0.6.2',
-        'elasticsearch>=6.0.0',
+        'elasticsearch>=6.0.0,<7.0.0',
         'jinja2==2.10.1',
         'mock==2.0.0',
         'numpy>=1.13.3',


### PR DESCRIPTION
- Added a defrost function reversing the freeze operation for dicts and lists
- defrost the connection configuration dict before passing it to Elasticsearch
- Fix Elasticsearch package version to be between 6.0 and 7.0

This allows us to correctly handle Elasticsearch connection parameters needed for HTTP basic auth.